### PR TITLE
Add SQLite database schema with FTS5 virtual tables

### DIFF
--- a/src/database/schema.sql
+++ b/src/database/schema.sql
@@ -1,0 +1,127 @@
+-- Fish MCP Server Database Schema
+-- SQLite with FTS5 Virtual Tables for full-text search
+
+-- メインの魚テーブル
+CREATE TABLE IF NOT EXISTS fish (
+  spec_code INTEGER PRIMARY KEY,
+  genus TEXT NOT NULL,
+  species TEXT NOT NULL,
+  scientific_name TEXT NOT NULL, -- genus + species
+  author TEXT,
+  fb_name TEXT, -- FishBase英語名
+  fam_code INTEGER,
+  family TEXT,
+  
+  -- 生息環境（boolean: 1=true, 0=false）
+  fresh INTEGER NOT NULL DEFAULT 0,
+  brackish INTEGER NOT NULL DEFAULT 0,
+  saltwater INTEGER NOT NULL DEFAULT 0,
+  habitat_zone TEXT CHECK (habitat_zone IN (
+    'demersal', 'benthopelagic', 'reef-associated', 'bathydemersal',
+    'bathypelagic', 'pelagic', 'pelagic-neritic', 'pelagic-oceanic', 'unknown'
+  )),
+  
+  -- サイズ・重量
+  length_cm REAL, -- 最大体長(cm)
+  common_length_cm REAL, -- 一般的なサイズ(cm)
+  weight_g REAL, -- 最大重量(g)
+  
+  -- 深度
+  depth_range_shallow_m REAL,
+  depth_range_deep_m REAL,
+  
+  -- 特性
+  dangerous TEXT CHECK (dangerous IN (
+    'harmless', 'venomous', 'traumatogenic', 
+    'reports of ciguatera poisoning', 'potential pest', 
+    'poisonous to eat', 'other'
+  )),
+  gamefish INTEGER NOT NULL DEFAULT 0,
+  aquarium TEXT CHECK (aquarium IN (
+    'never/rarely', 'commercial', 'public aquariums', 
+    'highly commercial', 'potential', 'show aquarium'
+  )),
+  aquaculture_use TEXT CHECK (aquaculture_use IN (
+    'never/rarely', 'commercial', 'experimental', 'likely future use'
+  )),
+  bait_use TEXT CHECK (bait_use IN (
+    'never/rarely', 'usually', 'occasionally'
+  )),
+  importance TEXT CHECK (importance IN (
+    'highly commercial', 'commercial', 'minor commercial',
+    'subsistence fisheries', 'of potential interest', 
+    'of no interest', 'bycatch'
+  )),
+  price_category TEXT CHECK (price_category IN (
+    'very high', 'high', 'medium', 'low', 'unknown'
+  )),
+  
+  -- 生物学的特性
+  body_shape TEXT CHECK (body_shape IN (
+    'elongated', 'fusiform / normal', 'short and / or deep', 
+    'eel-like', 'other'
+  )),
+  migration_pattern TEXT CHECK (migration_pattern IN (
+    'non-migratory', 'oceanodromous', 'potamodromous', 
+    'amphidromous', 'anadromous', 'catadromous', 
+    'oceano-estuarine', 'diadromous'
+  )),
+  electric_ability TEXT CHECK (electric_ability IN (
+    'no special ability', 'electrosensing only', 
+    'weakly discharging', 'strongly discharging'
+  )),
+  
+  -- 説明文
+  comments TEXT,
+  remarks TEXT,
+  
+  -- メタデータ
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+-- fishテーブルのインデックス
+CREATE INDEX IF NOT EXISTS idx_fish_genus_species ON fish(genus, species);
+CREATE INDEX IF NOT EXISTS idx_fish_habitat ON fish(habitat_zone);
+CREATE INDEX IF NOT EXISTS idx_fish_environment ON fish(fresh, brackish, saltwater);
+CREATE INDEX IF NOT EXISTS idx_fish_size ON fish(length_cm, weight_g);
+CREATE INDEX IF NOT EXISTS idx_fish_depth ON fish(depth_range_shallow_m, depth_range_deep_m);
+CREATE INDEX IF NOT EXISTS idx_fish_dangerous ON fish(dangerous);
+
+-- 一般名テーブル（日本語・英語のみ）
+CREATE TABLE IF NOT EXISTS common_names (
+  id INTEGER PRIMARY KEY,
+  com_name TEXT NOT NULL,
+  spec_code INTEGER NOT NULL,
+  language TEXT NOT NULL CHECK (language IN ('English', 'Japanese')),
+  preferred_name INTEGER NOT NULL DEFAULT 0, -- boolean
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  
+  FOREIGN KEY (spec_code) REFERENCES fish(spec_code)
+);
+
+-- common_namesテーブルのインデックス
+CREATE INDEX IF NOT EXISTS idx_common_names_spec_code ON common_names(spec_code);
+CREATE INDEX IF NOT EXISTS idx_common_names_language ON common_names(language);
+CREATE INDEX IF NOT EXISTS idx_common_names_name ON common_names(com_name);
+
+-- FTS5 Virtual Table: 魚の全文検索
+-- 日本語と英語での検索を高速化
+CREATE VIRTUAL TABLE IF NOT EXISTS fish_search USING fts5(
+  scientific_name,
+  fb_name,
+  comments,
+  remarks,
+  -- 一般名も含める（結合して追加）
+  japanese_names,
+  english_names,
+  content='fish',
+  content_rowid='spec_code'
+);
+
+-- FTS5 Virtual Table: 一般名での検索
+CREATE VIRTUAL TABLE IF NOT EXISTS name_search USING fts5(
+  com_name,
+  language,
+  content='common_names', 
+  content_rowid='id'
+);


### PR DESCRIPTION
## Summary
- Implemented SQLite database schema optimized for fish data storage and search
- Added FTS5 virtual tables for high-performance Japanese/English full-text search
- Included CHECK constraints for data integrity on all enum fields
- Created efficient indexes based on expected query patterns

## Database Design Highlights

### Primary Key Decision
Used `spec_code` as PRIMARY KEY instead of a separate `id` column:
- Eliminates redundant storage
- Natural key from FishBase data
- Simplifies foreign key relationships

### FTS5 Virtual Tables
Two virtual tables for different search needs:
1. `fish_search`: Full-text search on fish descriptions and names
2. `name_search`: Dedicated search for common names by language

### Data Integrity
All enum fields have CHECK constraints matching TypeScript definitions:
```sql
dangerous TEXT CHECK (dangerous IN (
    'harmless', 'venomous', 'traumatogenic', ...
))
```

### Schema Features
- **fish table**: Core fish data with all TypeScript-defined fields
- **common_names table**: Multilingual names (English/Japanese only for MVP)
- **Indexes**: Strategic indexes on frequently queried columns
- **Foreign keys**: Referential integrity between tables

## Test Plan
- [ ] Schema creates successfully in SQLite
- [ ] CHECK constraints reject invalid enum values
- [ ] FTS5 tables support Japanese text search
- [ ] Indexes improve query performance
- [ ] Foreign key constraints work correctly

## Related PRs
- #1: Type definitions that this schema implements

🤖 Generated with [Claude Code](https://claude.ai/code)