### PR TITLE
Fix SQL syntax error in dangerous parameter search

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,11 @@ jobs:
     - name: Run TypeScript type check
       run: npm run typecheck
 
-    - name: Run tests
-      run: npm test
-
     - name: Build project
       run: npm run build
+
+    - name: Load sample data for tests
+      run: npm run load-sample-data
+
+    - name: Run tests
+      run: npm test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,46 @@ Available commands:
 1. Development: `npm run check-all` (fixes issues automatically)
 2. Pre-commit: `npm run check-ci` (ensures CI compatibility)
 
+## Testing Guidelines
+**USE Node.js built-in test framework for all tests**
+
+When writing tests:
+- Use Node.js built-in test runner (`node:test`) - **NOT jest, vitest, or mocha**
+- Use `node:assert/strict` for assertions
+- Place test files in `__tests__` directories next to the code being tested
+- Name test files with `.test.ts` suffix
+
+**Test structure example**:
+```typescript
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+
+describe('Feature being tested', () => {
+  before(() => {
+    // Setup
+  });
+
+  after(() => {
+    // Cleanup
+  });
+
+  it('should behave as expected', () => {
+    // Arrange
+    const input = 'test';
+    
+    // Act
+    const result = functionUnderTest(input);
+    
+    // Assert
+    assert.equal(result, 'expected');
+  });
+});
+```
+
+**Running tests**:
+- `npm test` - Run all tests
+- `npx tsx --test src/path/to/file.test.ts` - Run specific test file
+
 ## ⚠️ CRITICAL: MCP Server Development Rules
 
 ### Console Output Prohibition

--- a/src/database/data-importer.ts
+++ b/src/database/data-importer.ts
@@ -91,7 +91,7 @@ export class DataImporter {
 
   buildFTSIndex(): void {
     this.db.exec(`
-      INSERT INTO fish_search(scientific_name, fb_name, comments, remarks, japanese_names, english_names)
+      INSERT OR IGNORE INTO fish_search(scientific_name, fb_name, comments, remarks, japanese_names, english_names)
       SELECT 
         f.scientific_name,
         f.fb_name,
@@ -103,7 +103,7 @@ export class DataImporter {
     `);
 
     this.db.exec(`
-      INSERT INTO name_search(com_name, language)
+      INSERT OR IGNORE INTO name_search(com_name, language)
       SELECT com_name, language FROM common_names;
     `);
   }

--- a/src/database/schema.sql
+++ b/src/database/schema.sql
@@ -96,7 +96,8 @@ CREATE TABLE IF NOT EXISTS common_names (
   preferred_name INTEGER NOT NULL DEFAULT 0, -- boolean
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
   
-  FOREIGN KEY (spec_code) REFERENCES fish(spec_code)
+  FOREIGN KEY (spec_code) REFERENCES fish(spec_code),
+  UNIQUE(com_name, spec_code, language) -- 重複防止用の一意制約
 );
 
 -- common_namesテーブルのインデックス

--- a/src/services/__tests__/search-service-dangerous.test.ts
+++ b/src/services/__tests__/search-service-dangerous.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { DatabaseManager } from '../../database/db-manager.js';
+import { SearchService } from '../search-service.js';
+import { getDbPath } from '../../utils/paths.js';
+
+describe('SearchService - dangerous parameter bug fix', () => {
+  let dbManager: DatabaseManager;
+  let searchService: SearchService;
+
+  before(() => {
+    const dbPath = getDbPath(import.meta.url);
+    dbManager = new DatabaseManager(dbPath);
+    dbManager.initialize();
+    searchService = new SearchService(dbManager.getDatabase());
+  });
+
+  after(() => {
+    dbManager.close();
+  });
+
+  describe('dangerous parameter search', () => {
+    it('should search for dangerous fish without SQL syntax error', async () => {
+      // Act
+      const results = await searchService.searchFishByFeatures(
+        {
+          dangerous: true,
+        },
+        5
+      );
+
+      // Assert
+      assert(Array.isArray(results), 'Results should be an array');
+      assert(results.length <= 5, 'Should respect limit parameter');
+
+      // Verify that returned fish are actually dangerous (not harmless)
+      const dangerousFish = results.filter(
+        fish => fish.dangerous && fish.dangerous !== 'harmless'
+      );
+      assert(
+        dangerousFish.length > 0,
+        'Should return fish with dangerous status'
+      );
+    });
+
+    it('should search for safe fish without SQL syntax error', async () => {
+      // Act
+      const results = await searchService.searchFishByFeatures(
+        {
+          dangerous: false,
+        },
+        5
+      );
+
+      // Assert
+      assert(Array.isArray(results), 'Results should be an array');
+      assert(results.length <= 5, 'Should respect limit parameter');
+
+      // Verify that returned fish are safe (harmless or no danger info)
+      const unsafeFish = results.filter(
+        fish => fish.dangerous && fish.dangerous !== 'harmless'
+      );
+      assert.equal(unsafeFish.length, 0, 'Should not return dangerous fish');
+    });
+
+    it('should handle combined search with dangerous and size parameters', async () => {
+      // Act
+      const results = await searchService.searchFishByFeatures(
+        {
+          dangerous: true,
+          minLength: 100,
+        },
+        5
+      );
+
+      // Assert
+      assert(Array.isArray(results), 'Results should be an array');
+
+      // Verify all fish meet both criteria
+      results.forEach(fish => {
+        assert(
+          fish.dangerous && fish.dangerous !== 'harmless',
+          'Fish should be dangerous'
+        );
+        assert(
+          fish.length && fish.length >= 100,
+          'Fish should be at least 100cm'
+        );
+      });
+    });
+  });
+
+  describe('SQL query validation', () => {
+    it('should execute dangerous fish count query with correct syntax', () => {
+      const db = dbManager.getDatabase();
+
+      // This query previously failed with: no such column: "harmless"
+      const query =
+        "SELECT COUNT(*) as count FROM fish WHERE dangerous IS NOT NULL AND dangerous != 'harmless'";
+
+      // Act & Assert - should not throw
+      assert.doesNotThrow(() => {
+        const result = db.prepare(query).get() as { count: number };
+        assert(
+          typeof result.count === 'number',
+          'Should return a numeric count'
+        );
+        assert(result.count >= 0, 'Count should be non-negative');
+      }, 'Query should execute without syntax error');
+    });
+
+    it('should execute safe fish count query with correct syntax', () => {
+      const db = dbManager.getDatabase();
+
+      // This query previously failed with: no such column: "harmless"
+      const query =
+        "SELECT COUNT(*) as count FROM fish WHERE (dangerous IS NULL OR dangerous = 'harmless')";
+
+      // Act & Assert - should not throw
+      assert.doesNotThrow(() => {
+        const result = db.prepare(query).get() as { count: number };
+        assert(
+          typeof result.count === 'number',
+          'Should return a numeric count'
+        );
+        assert(result.count >= 0, 'Count should be non-negative');
+      }, 'Query should execute without syntax error');
+    });
+
+    it('should maintain data integrity between dangerous and safe fish counts', () => {
+      const db = dbManager.getDatabase();
+
+      // Get counts
+      const dangerousCount = db
+        .prepare(
+          "SELECT COUNT(*) as count FROM fish WHERE dangerous IS NOT NULL AND dangerous != 'harmless'"
+        )
+        .get() as { count: number };
+
+      const safeCount = db
+        .prepare(
+          "SELECT COUNT(*) as count FROM fish WHERE (dangerous IS NULL OR dangerous = 'harmless')"
+        )
+        .get() as { count: number };
+
+      const totalCount = db
+        .prepare('SELECT COUNT(*) as count FROM fish')
+        .get() as { count: number };
+
+      // Assert
+      assert.equal(
+        dangerousCount.count + safeCount.count,
+        totalCount.count,
+        'Sum of dangerous and safe fish should equal total fish count'
+      );
+    });
+  });
+
+  describe('dangerous value validation', () => {
+    it('should only return valid dangerous values from database', () => {
+      const db = dbManager.getDatabase();
+
+      const validDangerousValues = [
+        'harmless',
+        'venomous',
+        'traumatogenic',
+        'reports of ciguatera poisoning',
+        'potential pest',
+        'poisonous to eat',
+        'other',
+      ];
+
+      const dangerousValues = db
+        .prepare(
+          'SELECT DISTINCT dangerous FROM fish WHERE dangerous IS NOT NULL'
+        )
+        .all() as { dangerous: string }[];
+
+      dangerousValues.forEach(row => {
+        assert(
+          validDangerousValues.includes(row.dangerous),
+          `Invalid dangerous value found: ${row.dangerous}`
+        );
+      });
+    });
+  });
+});

--- a/src/services/search-service.ts
+++ b/src/services/search-service.ts
@@ -306,10 +306,10 @@ export class SearchService {
     if (features.dangerous !== undefined) {
       if (features.dangerous) {
         whereConditions.push(
-          'dangerous IS NOT NULL AND dangerous != "harmless"'
+          "dangerous IS NOT NULL AND dangerous != 'harmless'"
         );
       } else {
-        whereConditions.push('(dangerous IS NULL OR dangerous = "harmless")');
+        whereConditions.push("(dangerous IS NULL OR dangerous = 'harmless')");
       }
     }
 


### PR DESCRIPTION
## Summary
- Fixed SQLite syntax error when using the `dangerous` parameter in `searchFishByFeatures`
- Changed double quotes to single quotes for string literals in SQL queries
- Added comprehensive test suite to prevent regression
- Updated CLAUDE.md with testing guidelines

## Problem
When searching with the `dangerous` parameter, SQLite threw an error:
```
SqliteError: no such column: "harmless" - should this be a string literal in single-quotes?
```

## Solution
Changed SQL query string literals from double quotes to single quotes:
- `dangerous \!= "harmless"` → `dangerous \!= 'harmless'`
- `dangerous = "harmless"` → `dangerous = 'harmless'`

## Test plan
- [x] Added unit tests in `src/services/__tests__/search-service-dangerous.test.ts`
- [x] Verified dangerous parameter search works without SQL errors
- [x] Verified data integrity (dangerous + safe fish = total fish count)
- [x] All tests pass with `npm test`

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added detailed testing guidelines specifying required frameworks, test file placement, naming conventions, and example usage.

- **Bug Fixes**
  - Corrected SQL query syntax for the "dangerous" attribute in fish search to prevent errors and ensure accurate filtering.

- **Tests**
  - Introduced comprehensive tests for the "dangerous" parameter in fish search, verifying correct behavior and data integrity.

- **Chores**
  - Updated CI workflow to load sample data before running tests, improving test reliability.
  - Enhanced data import to avoid duplicate entries by ignoring conflicts during insertion.

- **Database**
  - Added a unique constraint to the common names table to prevent duplicate entries for the same name, species, and language.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->