### PR TITLE
feat: Remove unused remarks field from database schema

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -82,6 +82,11 @@
   - コメント・説明文検索を削除（特徴検索は新規実装するsearchFishByNaturalLanguageの責務）
   - 名前検索（日本語名、英語名、学名）に特化
   - 現在の検索優先順位（完全一致→部分一致→FTS5）は適切なため維持
+- [x] **未使用のremarksフィールドを削除**
+  - schema.sqlからremarksカラム削除
+  - FTS5のfish_searchテーブルからremarksフィールド削除
+  - data-loader.tsからRemarksマッピング削除（Parquetには存在しない）
+  - Fish型定義からremarksフィールド削除
 - [ ] **searchFishByNaturalLanguage関数の新規実装（Phase 1: 基本機能）**
   - SearchServiceにsearchFishByNaturalLanguageメソッド追加
   - FTS5を使用してcommentsフィールドを直接全文検索

--- a/scripts/load-sample-data.ts
+++ b/scripts/load-sample-data.ts
@@ -54,7 +54,6 @@ async function loadSampleData() {
         importance: CommercialImportance.HIGHLY_COMMERCIAL,
         bodyShape: BodyShape.FUSIFORM,
         comments: '大型の回遊魚で、高速で泳ぐ。商業的に重要な魚種。',
-        remarks: '危険性は低いが、大きな個体は注意が必要。',
       },
       {
         specCode: 2,
@@ -79,7 +78,6 @@ async function loadSampleData() {
         importance: CommercialImportance.MINOR_COMMERCIAL,
         bodyShape: BodyShape.FUSIFORM,
         comments: '大型の肉食性サメ。非常に危険。',
-        remarks: '深海から浅海まで広く分布。攻撃的で危険な魚。',
       },
       {
         specCode: 3,
@@ -103,7 +101,6 @@ async function loadSampleData() {
         aquarium: AquariumSuitability.NO,
         importance: CommercialImportance.COMMERCIAL,
         comments: '深海魚の一種。美しい赤色。',
-        remarks: '深海に生息する。毒はないが棘に注意。',
       },
       {
         specCode: 4,
@@ -127,7 +124,6 @@ async function loadSampleData() {
         aquarium: AquariumSuitability.YES,
         importance: CommercialImportance.NO_INTEREST,
         comments: '小型のフグ。体に毒を持つ。',
-        remarks: '観賞魚として人気があるが、取り扱いに注意が必要。',
       },
     ];
 

--- a/src/database/data-importer.ts
+++ b/src/database/data-importer.ts
@@ -18,7 +18,7 @@ export class DataImporter {
         depth_range_shallow_m, depth_range_deep_m,
         dangerous, gamefish, aquarium, aquaculture_use, bait_use, importance, price_category,
         body_shape, migration_pattern, electric_ability,
-        comments, remarks
+        comments
       ) VALUES (
         ?, ?, ?, ?, ?, ?, ?, ?,
         ?, ?, ?, ?,
@@ -26,7 +26,7 @@ export class DataImporter {
         ?, ?,
         ?, ?, ?, ?, ?, ?, ?,
         ?, ?, ?,
-        ?, ?
+        ?
       )
     `);
 
@@ -60,8 +60,7 @@ export class DataImporter {
           f.bodyShape,
           f.migrationPattern,
           f.electricAbility,
-          f.comments,
-          f.remarks
+          f.comments
         );
       }
     });
@@ -91,12 +90,11 @@ export class DataImporter {
 
   buildFTSIndex(): void {
     this.db.exec(`
-      INSERT OR IGNORE INTO fish_search(scientific_name, fb_name, comments, remarks, japanese_names, english_names)
+      INSERT OR IGNORE INTO fish_search(scientific_name, fb_name, comments, japanese_names, english_names)
       SELECT 
         f.scientific_name,
         f.fb_name,
         f.comments,
-        f.remarks,
         (SELECT GROUP_CONCAT(cn1.com_name, ' ') FROM common_names cn1 WHERE cn1.spec_code = f.spec_code AND cn1.language = 'Japanese'),
         (SELECT GROUP_CONCAT(cn2.com_name, ' ') FROM common_names cn2 WHERE cn2.spec_code = f.spec_code AND cn2.language = 'English')
       FROM fish f;

--- a/src/database/schema.sql
+++ b/src/database/schema.sql
@@ -73,7 +73,6 @@ CREATE TABLE IF NOT EXISTS fish (
   
   -- 説明文
   comments TEXT,
-  remarks TEXT,
   
   -- メタデータ
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP
@@ -111,7 +110,6 @@ CREATE VIRTUAL TABLE IF NOT EXISTS fish_search USING fts5(
   scientific_name,
   fb_name,
   comments,
-  remarks,
   -- 一般名も含める（結合して追加）
   japanese_names,
   english_names,

--- a/src/services/__tests__/search-service.test.ts
+++ b/src/services/__tests__/search-service.test.ts
@@ -37,7 +37,6 @@ describe('SearchService', () => {
         gamefish: true,
         comments:
           'A large oceanic fish found in tropical and subtropical waters',
-        remarks: 'Important commercial fish for tuna industry',
       },
       {
         specCode: 2,
@@ -50,7 +49,6 @@ describe('SearchService', () => {
         saltwater: true,
         gamefish: false,
         comments: 'Common pelagic fish in the Pacific Ocean',
-        remarks: 'Forms large schools',
       },
       {
         specCode: 3,
@@ -63,7 +61,6 @@ describe('SearchService', () => {
         saltwater: true,
         gamefish: false,
         comments: 'Butterfly fish with golden coloration',
-        remarks: 'Found in coral reefs',
       },
       {
         specCode: 4,
@@ -76,7 +73,6 @@ describe('SearchService', () => {
         saltwater: false,
         gamefish: false,
         comments: 'Freshwater loach species',
-        remarks: 'Used in traditional medicine',
       },
     ];
 

--- a/src/services/data-loader.ts
+++ b/src/services/data-loader.ts
@@ -43,7 +43,6 @@ interface FishBaseSpeciesRow {
   Migration?: string;
   Electric?: string;
   Comments?: string;
-  Remarks?: string;
 }
 
 interface FishBaseCommonNameRow {
@@ -374,7 +373,6 @@ export class FishBaseDataLoader {
       migrationPattern: this.normalizeMigrationPattern(row.Migration),
       electricAbility: this.normalizeElectricAbility(row.Electric),
       comments: row.Comments,
-      remarks: row.Remarks,
     };
   }
 

--- a/src/services/search-service.ts
+++ b/src/services/search-service.ts
@@ -85,7 +85,6 @@ interface FishDbRow {
   migration_pattern?: string;
   electric_ability?: string;
   comments?: string;
-  remarks?: string;
   match_type?: string;
   matched_name?: string;
 }
@@ -418,7 +417,6 @@ export class SearchService {
       migrationPattern: row.migration_pattern as MigrationPattern | undefined,
       electricAbility: row.electric_ability as ElectricAbility | undefined,
       comments: row.comments,
-      remarks: row.remarks,
       matchType: row.match_type || 'unknown',
       matchedName: row.matched_name,
     }));

--- a/src/types/fish.ts
+++ b/src/types/fish.ts
@@ -146,7 +146,6 @@ export interface Fish {
 
   // 説明
   comments?: string; // 詳細な説明
-  remarks?: string; // 備考
 
   // 画像情報
   images?: FishImage[]; // 画像情報配列（外部API経由で取得）


### PR DESCRIPTION
## Summary
- Remove the unused `remarks` field from the database schema and codebase
- The field was never populated from FishBase data (Parquet contains `Remarks7` with only 728 short notes vs 23,079 detailed `Comments`)
- Simplifies the schema and reduces confusion

## Changes
- ✅ Remove `remarks` column from fish table schema
- ✅ Remove `remarks` field from FTS5 fish_search virtual table  
- ✅ Remove `Remarks` mapping from data-loader.ts
- ✅ Remove `remarks` field from Fish type definition
- ✅ Update SearchService to remove remarks-related processing
- ✅ Fix data-importer.ts INSERT statement placeholder count
- ✅ Update tests and sample data to exclude remarks field

## Test Plan
- [x] All unit tests pass
- [x] TypeScript compilation successful
- [x] ESLint and Prettier checks pass
- [x] Sample data loads successfully without errors
- [x] Search functionality continues to work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the unused "remarks" field from all fish-related data, interfaces, and database tables to streamline the data model.

- **Tests**
  - Updated test data to remove the "remarks" field from fish objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->