### PR TITLE
feat: Implement natural language search functionality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,23 @@ Available commands:
 1. Development: `npm run check-all` (fixes issues automatically)
 2. Pre-commit: `npm run check-ci` (ensures CI compatibility)
 
+## ⚠️ CRITICAL: Pre-commit Hook Policy
+
+### 🚫 STRICTLY FORBIDDEN:
+- **NEVER use `git commit --no-verify`** to bypass pre-commit hooks
+- **NEVER use `git commit -n`** to skip verification
+- **NEVER bypass quality gates** under any circumstances
+
+### ✅ REQUIRED when pre-commit hook fails:
+1. **STOP**: Do not attempt to bypass the hook
+2. **READ**: Examine the exact error message carefully
+3. **FIX**: Resolve the root cause (not symptoms)
+4. **TEST**: Run full test suite locally (`npm test`)
+5. **VERIFY**: Ensure all quality checks pass
+6. **COMMIT**: Only after complete resolution
+
+**Remember**: Pre-commit hooks are the final quality gate. Bypassing them compromises the entire codebase integrity.
+
 ## Testing Guidelines
 **USE Node.js built-in test framework for all tests**
 

--- a/TODO.md
+++ b/TODO.md
@@ -87,11 +87,13 @@
   - FTS5のfish_searchテーブルからremarksフィールド削除
   - data-loader.tsからRemarksマッピング削除（Parquetには存在しない）
   - Fish型定義からremarksフィールド削除
-- [ ] **searchFishByNaturalLanguage関数の新規実装（Phase 1: 基本機能）**
-  - SearchServiceにsearchFishByNaturalLanguageメソッド追加
-  - FTS5を使用してcommentsフィールドを直接全文検索
-  - 基本的な自然言語クエリをサポート
-  - MCPツール「search_fish_by_natural_language」として公開
+- [x] **searchFishByNaturalLanguage関数の新規実装（Phase 1: 基本機能）**
+  - [x] SearchServiceにsearchFishByNaturalLanguageメソッド追加
+  - [x] FTS5を使用してcommentsフィールドを直接全文検索
+  - [x] 基本的な自然言語クエリをサポート
+  - [x] MCPツール「search_fish_by_natural_language」として公開
+  - [x] FTS5スキーマをcontentlessに修正（japanese_names/english_names問題解決）
+  - [x] テストコード作成（12個のテストケース）
 - [ ] **searchFishByNaturalLanguage機能拡張（Phase 2: スコアリング）**
   - FTS5のrank/bm25スコアリングを使用して関連性順にソート
   - 低スコアの結果をフィルタリングして検索精度を向上
@@ -101,6 +103,10 @@
   - 統合テストの実装
   - スコア閾値の最適化
   - パフォーマンス検証
+- [ ] **FTS5トークナイザーの改善**
+  - Unicode61 tokenizerの語幹処理問題を解決（reef/reefsなどの単複形マッチング）
+  - クエリ前処理で一般的な単複形パターンを対応（fish/fishes, reef/reefsなど）
+  - ICU tokenizerへのアップグレードを検討（長期的改善）
 - [ ] **検索精度向上のためのテストケース作成**
   - より網羅的な日本語検索テスト
   - ローマ字検索のテストカバレッジ拡大

--- a/src/database/schema.sql
+++ b/src/database/schema.sql
@@ -107,7 +107,8 @@ CREATE INDEX IF NOT EXISTS idx_common_names_name ON common_names(com_name);
 -- FTS5 Virtual Table: 魚の全文検索（contentless）
 -- 日本語と英語での検索を高速化
 -- contentlessのため手動でデータ投入が必要
-CREATE VIRTUAL TABLE IF NOT EXISTS fish_search USING fts5(
+DROP TABLE IF EXISTS fish_search;
+CREATE VIRTUAL TABLE fish_search USING fts5(
   scientific_name,
   fb_name,
   comments,
@@ -117,7 +118,8 @@ CREATE VIRTUAL TABLE IF NOT EXISTS fish_search USING fts5(
 );
 
 -- FTS5 Virtual Table: 一般名での検索
-CREATE VIRTUAL TABLE IF NOT EXISTS name_search USING fts5(
+DROP TABLE IF EXISTS name_search;
+CREATE VIRTUAL TABLE name_search USING fts5(
   com_name,
   language,
   content='common_names', 

--- a/src/database/schema.sql
+++ b/src/database/schema.sql
@@ -104,17 +104,15 @@ CREATE INDEX IF NOT EXISTS idx_common_names_spec_code ON common_names(spec_code)
 CREATE INDEX IF NOT EXISTS idx_common_names_language ON common_names(language);
 CREATE INDEX IF NOT EXISTS idx_common_names_name ON common_names(com_name);
 
--- FTS5 Virtual Table: 魚の全文検索
+-- FTS5 Virtual Table: 魚の全文検索（contentless）
 -- 日本語と英語での検索を高速化
+-- contentlessのため手動でデータ投入が必要
 CREATE VIRTUAL TABLE IF NOT EXISTS fish_search USING fts5(
   scientific_name,
   fb_name,
   comments,
-  -- 一般名も含める（結合して追加）
-  japanese_names,
-  english_names,
-  content='fish',
-  content_rowid='spec_code',
+  japanese_names,  -- common_namesテーブルから集約
+  english_names,   -- common_namesテーブルから集約
   tokenize='unicode61 remove_diacritics 1'  -- 日本語対応tokenizer（SQLite標準）
 );
 

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -70,3 +70,25 @@ export const searchFishByFeaturesTool: Tool = {
     required: [],
   },
 };
+
+export const searchFishByNaturalLanguageTool: Tool = {
+  name: 'search_fish_by_natural_language',
+  description:
+    '自然言語で魚を検索します。魚の説明文（生態、特徴、用途など）から検索できます。英語での検索を推奨します。',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      query: {
+        type: 'string',
+        description:
+          '自然言語の検索クエリ（例: "deep sea dangerous fish", "tropical colorful fish", "commercial food fish"）。注：データベースの説明文は主に英語のため、英語での検索を推奨します。',
+      },
+      limit: {
+        type: 'number',
+        description: '検索結果の最大件数（デフォルト: 10）',
+        default: 10,
+      },
+    },
+    required: ['query'],
+  },
+};

--- a/src/services/__tests__/search-service-natural-language.test.ts
+++ b/src/services/__tests__/search-service-natural-language.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import Database from 'better-sqlite3';
+import { SearchService } from '../search-service.js';
+import { DatabaseManager } from '../../database/db-manager.js';
+import { DataImporter } from '../../database/data-importer.js';
+import { Fish } from '../../types/fish.js';
+
+describe('SearchService - Natural Language Search', () => {
+  let db: Database.Database;
+  let searchService: SearchService;
+  let dbManager: DatabaseManager;
+
+  before(() => {
+    // In-memory database for testing
+    dbManager = new DatabaseManager(':memory:');
+    dbManager.initialize();
+    db = dbManager.getDatabase();
+    searchService = new SearchService(db);
+
+    // Setup test data
+    const dataImporter = new DataImporter(db);
+
+    // Insert test fish data with comments
+    const testFish: Fish[] = [
+      {
+        specCode: 1,
+        genus: 'Carcharodon',
+        species: 'carcharias',
+        scientificName: 'Carcharodon carcharias',
+        fbName: 'Great white shark',
+        fresh: false,
+        brackish: false,
+        saltwater: true,
+        gamefish: true,
+        comments: 'A large predatory shark found in coastal waters. Known for its size and power. Dangerous to humans.',
+      },
+      {
+        specCode: 2,
+        genus: 'Amphiprion',
+        species: 'ocellaris',
+        scientificName: 'Amphiprion ocellaris',
+        fbName: 'False clownfish',
+        fresh: false,
+        brackish: false,
+        saltwater: true,
+        gamefish: false,
+        comments: 'Popular aquarium fish living in coral reefs with sea anemones. Bright orange color with white stripes.',
+      },
+      {
+        specCode: 3,
+        genus: 'Melanocetus',
+        species: 'johnsonii',
+        scientificName: 'Melanocetus johnsonii',
+        fbName: 'Humpback anglerfish',
+        fresh: false,
+        brackish: false,
+        saltwater: true,
+        gamefish: false,
+        comments: 'Deep sea fish with bioluminescent lure. Lives in complete darkness at depths over 1000 meters.',
+      },
+      {
+        specCode: 4,
+        genus: 'Thunnus',
+        species: 'thynnus',
+        scientificName: 'Thunnus thynnus',
+        fbName: 'Atlantic bluefin tuna',
+        fresh: false,
+        brackish: false,
+        saltwater: true,
+        gamefish: true,
+        comments: 'Highly prized commercial fish. Fast swimming pelagic species. Important for sushi and sashimi.',
+      },
+      {
+        specCode: 5,
+        genus: 'Salmo',
+        species: 'salar',
+        scientificName: 'Salmo salar',
+        fbName: 'Atlantic salmon',
+        fresh: true,
+        brackish: true,
+        saltwater: true,
+        gamefish: true,
+        comments: 'Anadromous fish migrating between fresh and salt water. Important commercial aquaculture species.',
+      },
+    ];
+
+    // Import the test data
+    dataImporter.insertFish(testFish);
+
+    // Build FTS index using DataImporter
+    dataImporter.buildFTSIndex();
+  });
+
+  after(() => {
+    dbManager.close();
+  });
+
+  describe('searchFishByNaturalLanguage', () => {
+    it('should find fish by habitat description', async () => {
+      const results = await searchService.searchFishByNaturalLanguage('deep sea');
+      assert.equal(results.length, 1);
+      assert.equal(results[0].scientificName, 'Melanocetus johnsonii');
+    });
+
+    it('should find dangerous fish', async () => {
+      const results = await searchService.searchFishByNaturalLanguage('dangerous');
+      assert.equal(results.length, 1);
+      assert.equal(results[0].scientificName, 'Carcharodon carcharias');
+    });
+
+    it('should find fish by use case', async () => {
+      const results = await searchService.searchFishByNaturalLanguage('commercial aquaculture');
+      assert.equal(results.length, 1);
+      assert.equal(results[0].scientificName, 'Salmo salar');
+    });
+
+    it('should find fish by color description', async () => {
+      const results = await searchService.searchFishByNaturalLanguage('orange color');
+      assert.equal(results.length, 1);
+      assert.equal(results[0].scientificName, 'Amphiprion ocellaris');
+    });
+
+    it('should find fish by food use', async () => {
+      const results = await searchService.searchFishByNaturalLanguage('sushi sashimi');
+      assert.equal(results.length, 1);
+      assert.equal(results[0].scientificName, 'Thunnus thynnus');
+    });
+
+    it('should support AND queries', async () => {
+      const results = await searchService.searchFishByNaturalLanguage('coral reefs');
+      assert.equal(results.length, 1);
+      assert.equal(results[0].scientificName, 'Amphiprion ocellaris');
+    });
+
+    it('should support OR queries', async () => {
+      const results = await searchService.searchFishByNaturalLanguage('shark OR tuna');
+      assert.equal(results.length, 2);
+      const species = results.map(f => f.scientificName).sort();
+      assert.deepEqual(species, ['Carcharodon carcharias', 'Thunnus thynnus']);
+    });
+
+    it('should handle complex queries', async () => {
+      const results = await searchService.searchFishByNaturalLanguage('predatory coastal waters');
+      assert.equal(results.length, 1);
+      assert.equal(results[0].scientificName, 'Carcharodon carcharias');
+    });
+
+    it('should return empty array for no matches', async () => {
+      const results = await searchService.searchFishByNaturalLanguage('tropical freshwater cichlid');
+      assert.equal(results.length, 0);
+    });
+
+    it('should handle empty query', async () => {
+      const results = await searchService.searchFishByNaturalLanguage('');
+      assert.equal(results.length, 0);
+    });
+
+    it('should respect limit parameter', async () => {
+      const results = await searchService.searchFishByNaturalLanguage('fish', 2);
+      assert.equal(results.length, 2);
+    });
+
+    it('should include snippet in matchedName', async () => {
+      const results = await searchService.searchFishByNaturalLanguage('bioluminescent');
+      assert.equal(results.length, 1);
+      assert(results[0].matchedName?.includes('bioluminescent'));
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add searchFishByNaturalLanguage method for natural language queries on fish comments
- Fix FTS5 schema issues (contentless approach to resolve column mismatch)
- Add comprehensive MCP tool integration with snippet highlighting
- Include 12 test cases covering various natural language search scenarios

## Key Features
- 🔍 FTS5-based full-text search on comments field
- 🌐 Support for English natural language queries
- 📝 Snippet highlighting showing matched content
- 🤖 MCP tool integration for Claude Desktop
- ✅ Comprehensive test coverage

## Technical Changes
- Fix FTS5 schema from `content='fish'` to contentless to resolve japanese_names/english_names column issues
- Update DataImporter to use DELETE + INSERT pattern for FTS5 data rebuilding
- Add new MCP tool 'search_fish_by_natural_language' with English search recommendations
- Return FishWithMatch type to include match snippets and metadata
- Complete database migration for existing fish.db

## Test Plan
- [x] Natural language search tests (12 test cases)
- [x] FTS5 contentless schema migration
- [x] MCP tool integration
- [x] Database migration verification
- [x] Snippet highlighting functionality

## Breaking Changes
None - this is a pure feature addition

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced natural language search for fish, enabling queries on fish descriptions such as ecology, features, and uses.
  - Added a new tool for natural language fish search, accessible via the MCP interface with support for query limits.
- **Bug Fixes**
  - Enhanced full-text search indexing by rebuilding search indexes from scratch and resolving issues with Japanese and English name handling.
- **Tests**
  - Added comprehensive tests to ensure accuracy and robustness of the natural language search functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->