### PR TITLE
feat: adopt MCP ImageContent format for image responses

### DIFF
--- a/docs/decisions/012-mcp-imagecontent-format.md
+++ b/docs/decisions/012-mcp-imagecontent-format.md
@@ -1,0 +1,86 @@
+# ADR-012: MCP ImageContent形式の採用
+
+## Status
+Accepted
+
+## Context
+画像データをMCPサーバーから返す際、大量のトークンを消費する問題が発生していました。当初、Base64エンコードされた画像データをテキスト内に埋め込んで返していましたが、1枚の画像で数千〜数万トークンを消費することが判明しました。
+
+### 問題点
+1. Base64文字列をテキストとして返すと、Claude Desktopがその全文字をトークンとして処理
+2. 320x240pxにリサイズした画像でも約10KBのBase64データ = 約2,500トークン
+3. 複数の画像を返すと簡単にトークン上限に達する
+
+### 検討した選択肢
+1. **テキスト内Base64埋め込み（従来方式）**
+   - 利点：Claudeが画像データに直接アクセス可能
+   - 欠点：大量のトークン消費
+
+2. **URL形式のみ**
+   - 利点：軽量
+   - 欠点：Claude Desktopで画像が表示されない
+
+3. **MCP ImageContent形式**
+   - 利点：画像専用のコンテンツタイプとして処理
+   - 欠点：Claudeが画像データの中身にアクセスできない
+
+## Decision
+MCP仕様で定義されているImageContent形式を採用します。
+
+```typescript
+{
+  type: 'image',
+  data: base64String,  // data:プレフィックスなし
+  mimeType: 'image/jpeg'
+}
+```
+
+### MCP仕様の参照
+- MCP SDK 型定義: `node_modules/@modelcontextprotocol/sdk/dist/esm/types.d.ts`
+- ImageContentSchemaの定義が含まれている（2025年6月25日時点）
+- 公式仕様書での明確な記載は未確認
+
+MCP SDKの型定義において、`ImageContentSchema`は以下のように定義されています：
+```typescript
+export declare const ImageContentSchema: z.ZodObject<{
+    type: z.ZodLiteral<"image">;
+    data: z.ZodString;      // Base64エンコードされた画像データ
+    mimeType: z.ZodString;  // 画像のMIMEタイプ
+}>
+```
+
+### 実装の詳細
+1. パラメータ名を`includeImagesAsBase64`から`includeImageContent`に変更
+2. 画像データをテキストとは別のコンテンツオブジェクトとして返す
+3. data URLプレフィックスは含めない（純粋なBase64データのみ）
+
+## Consequences
+
+### 良い結果
+1. **トークン消費の削減**
+   - 画像データがテキストトークンとしてカウントされない可能性
+   - Claude Desktopが画像を適切に処理
+
+2. **MCP仕様準拠**
+   - 標準的な方法で画像を扱える
+   - 将来的な互換性の確保
+
+3. **表示品質の向上**
+   - Claude Desktopが`<output_image>`タグとして適切に表示
+
+### 悪い結果
+1. **Claudeによる画像データアクセス不可**
+   - HTMLアーティファクトなどで画像を使用する場合、Base64データにアクセスできない
+   - 画像の内容をプログラム的に処理できない
+
+2. **用途の制限**
+   - 画像表示専用となり、データとしての活用が困難
+
+### 緩和策
+- 画像リサイズ（320x240px、JPEG品質60%）は継続し、もしImageContent形式でもトークンがカウントされる場合の対策とする
+- 将来的に、用途に応じて複数の形式を選択できるようにすることを検討
+
+## Notes
+- 2025年6月25日時点で、ImageContent形式がClaude Desktopでどのように処理されるかは完全には明確でない
+- トークン削減効果については実運用での検証が必要
+- パラメータ構造（`includeImages`と`includeImageContent`の2つ）は将来的に見直しの余地あり

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -21,9 +21,10 @@ export const searchFishByNameTool: Tool = {
         description: '画像情報を含めるかどうか（デフォルト: false）',
         default: false,
       },
-      includeImagesAsBase64: {
+      includeImageContent: {
         type: 'boolean',
-        description: 'Base64形式で画像を含める（デフォルト: false）',
+        description:
+          '画像をImageContent形式で含める（画像専用のコンテンツタイプで返す）（デフォルト: false）',
         default: false,
       },
     },
@@ -71,9 +72,10 @@ export const searchFishByFeaturesTool: Tool = {
         description: '画像情報を含めるかどうか（デフォルト: false）',
         default: false,
       },
-      includeImagesAsBase64: {
+      includeImageContent: {
         type: 'boolean',
-        description: 'Base64形式で画像を含める（デフォルト: false）',
+        description:
+          '画像をImageContent形式で含める（画像専用のコンテンツタイプで返す）（デフォルト: false）',
         default: false,
       },
     },

--- a/src/services/__tests__/image-service-base64.test.ts
+++ b/src/services/__tests__/image-service-base64.test.ts
@@ -33,12 +33,12 @@ describe('ImageService Base64 functionality', () => {
         'Image should have Base64 data when includeBase64 is true'
       );
       assert.ok(
-        image.base64.startsWith('data:'),
-        'Base64 data should start with data:'
+        !image.base64.startsWith('data:'),
+        'Base64 data should not include data: prefix'
       );
       assert.ok(
-        image.base64.includes(';base64,'),
-        'Base64 data should include ;base64,'
+        !image.base64.includes(';base64,'),
+        'Base64 data should not include ;base64, prefix'
       );
 
       // Check MIME type

--- a/src/services/__tests__/search-service-base64.test.ts
+++ b/src/services/__tests__/search-service-base64.test.ts
@@ -21,7 +21,7 @@ describe('SearchService Base64 functionality', () => {
     db.close();
   });
 
-  it('should include Base64 images when includeImagesAsBase64 is true', async () => {
+  it('should include Base64 images when includeImageContent is true', async () => {
     const results = await searchService.searchFishByName(
       'tuna',
       3,
@@ -39,11 +39,11 @@ describe('SearchService Base64 functionality', () => {
       // Check that Base64 data is included
       assert.ok(
         image.base64,
-        'Image should have Base64 data when includeImagesAsBase64 is true'
+        'Image should have Base64 data when includeImageContent is true'
       );
       assert.ok(
-        image.base64.startsWith('data:'),
-        'Base64 data should be a data URL'
+        !image.base64.startsWith('data:'),
+        'Base64 data should not include data: prefix'
       );
       assert.ok(image.mimeType, 'Image should have MIME type');
 
@@ -71,12 +71,12 @@ describe('SearchService Base64 functionality', () => {
       assert.equal(
         image.base64,
         undefined,
-        'Image should not have Base64 data when includeImagesAsBase64 is false'
+        'Image should not have Base64 data when includeImageContent is false'
       );
       assert.equal(
         image.mimeType,
         undefined,
-        'Image should not have MIME type when includeImagesAsBase64 is false'
+        'Image should not have MIME type when includeImageContent is false'
       );
 
       // URL should be present
@@ -132,7 +132,7 @@ describe('SearchService Base64 functionality', () => {
         minLength: 50,
         maxLength: 100,
         includeImages: false,
-        includeImagesAsBase64: true,
+        includeImageContent: true,
       },
       3
     );
@@ -147,7 +147,7 @@ describe('SearchService Base64 functionality', () => {
       // Check that Base64 data is included
       assert.ok(
         image.base64,
-        'Image should have Base64 data when includeImagesAsBase64 is true'
+        'Image should have Base64 data when includeImageContent is true'
       );
       assert.ok(image.url, 'Image should still have URL');
     }

--- a/src/services/image-service.ts
+++ b/src/services/image-service.ts
@@ -198,12 +198,14 @@ export class ImageService {
 
       // 画像のリサイズ処理
       const buffer = Buffer.from(arrayBuffer);
+      debug('Original image size: %d bytes', buffer.length);
       const resizedBuffer = await this.resizeImage(buffer, resizeOptions);
+      debug('Resized image size: %d bytes', resizedBuffer.length);
 
       const base64 = resizedBuffer.toString('base64');
 
       return {
-        base64: `data:image/jpeg;base64,${base64}`,
+        base64: base64,
         mimeType: 'image/jpeg',
       };
     } catch (error) {

--- a/src/services/search-service.ts
+++ b/src/services/search-service.ts
@@ -28,7 +28,7 @@ export interface SearchFeatures {
   environment?: 'fresh' | 'brackish' | 'saltwater';
   gamefish?: boolean;
   includeImages?: boolean;
-  includeImagesAsBase64?: boolean;
+  includeImageContent?: boolean;
 }
 
 export type FishWithMatch = Fish & {
@@ -166,7 +166,7 @@ export class SearchService {
     query: string,
     limit: number = 10,
     includeImages: boolean = false,
-    includeImagesAsBase64: boolean = false
+    includeImageContent: boolean = false
   ): Promise<FishWithMatch[]> {
     // クエリの前処理
     const romajiQuery = this.toRomaji(query);
@@ -186,8 +186,8 @@ export class SearchService {
       .all(query, romajiQuery, limit) as FishDbRow[];
 
     if (results.length > 0) {
-      return includeImages || includeImagesAsBase64
-        ? this.transformDbRowsToFishWithImages(results, includeImagesAsBase64)
+      return includeImages || includeImageContent
+        ? this.transformDbRowsToFishWithImages(results, includeImageContent)
         : this.transformDbRowsToFish(results);
     }
 
@@ -208,8 +208,8 @@ export class SearchService {
       .all(`%${query}%`, `%${romajiQuery}%`, limit) as FishDbRow[];
 
     if (results.length > 0) {
-      return includeImages || includeImagesAsBase64
-        ? this.transformDbRowsToFishWithImages(results, includeImagesAsBase64)
+      return includeImages || includeImageContent
+        ? this.transformDbRowsToFishWithImages(results, includeImageContent)
         : this.transformDbRowsToFish(results);
     }
 
@@ -229,8 +229,8 @@ export class SearchService {
       .all(romajiQuery, limit) as FishDbRow[];
 
     if (results.length > 0) {
-      return includeImages || includeImagesAsBase64
-        ? this.transformDbRowsToFishWithImages(results, includeImagesAsBase64)
+      return includeImages || includeImageContent
+        ? this.transformDbRowsToFishWithImages(results, includeImageContent)
         : this.transformDbRowsToFish(results);
     }
 
@@ -250,8 +250,8 @@ export class SearchService {
         .all(query, limit) as FishDbRow[];
 
       if (results.length > 0) {
-        return includeImages || includeImagesAsBase64
-          ? this.transformDbRowsToFishWithImages(results, includeImagesAsBase64)
+        return includeImages || includeImageContent
+          ? this.transformDbRowsToFishWithImages(results, includeImageContent)
           : this.transformDbRowsToFish(results);
       }
     }
@@ -270,8 +270,8 @@ export class SearchService {
       )
       .all(`%${query}%`, limit) as FishDbRow[];
 
-    return includeImages || includeImagesAsBase64
-      ? this.transformDbRowsToFishWithImages(results, includeImagesAsBase64)
+    return includeImages || includeImageContent
+      ? this.transformDbRowsToFishWithImages(results, includeImageContent)
       : this.transformDbRowsToFish(results);
   }
 
@@ -402,10 +402,10 @@ export class SearchService {
       )
       .all(...params, limit) as FishDbRow[];
 
-    return features.includeImages || features.includeImagesAsBase64
+    return features.includeImages || features.includeImageContent
       ? this.transformDbRowsToFishWithImages(
           results,
-          features.includeImagesAsBase64 || false
+          features.includeImageContent || false
         )
       : this.transformDbRowsToFish(results);
   }
@@ -439,7 +439,7 @@ export class SearchService {
 
   private async transformDbRowsToFishWithImages(
     rows: FishDbRow[],
-    includeBase64: boolean = false
+    includeImageContent: boolean = false
   ): Promise<FishWithMatch[]> {
     const fishList = this.transformDbRowsToFish(rows);
 
@@ -449,7 +449,7 @@ export class SearchService {
         try {
           const images = await this.imageService.getImagesForFish(
             fish.scientificName,
-            includeBase64
+            includeImageContent
           );
           return { ...fish, images };
         } catch (error) {


### PR DESCRIPTION
## Summary
- Adopt MCP ImageContent format to address token consumption issues
- Rename `includeImagesAsBase64` to `includeImageContent` for clarity
- Document decision in ADR-012

## Background
When returning image data as Base64 strings embedded in text content, Claude Desktop processes all characters as tokens, leading to excessive token consumption (2,500+ tokens per small image).

## Changes
1. **Parameter Rename**: `includeImagesAsBase64` → `includeImageContent`
   - Better reflects that we're returning ImageContent format, not raw Base64 strings
   
2. **Response Format**: Images now returned as separate content objects
   ```typescript
   {
     type: 'image',
     data: base64String,  // without data: prefix
     mimeType: 'image/jpeg'
   }
   ```

3. **ImageService Update**: Remove data URL prefix from base64 data
4. **Test Updates**: All tests updated to use new parameter name
5. **ADR-012**: Document the decision and rationale

## Impact
- **Token Usage**: Potential reduction in token consumption (needs verification)
- **Display**: Images shown as `<output_image>` tags in Claude Desktop
- **Limitation**: Claude cannot programmatically access image data content

## Test Results
- All 60 tests passing ✅
- ESLint, Prettier, TypeScript checks passing ✅

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Search results now use a structured format, displaying text and images as separate content blocks for improved clarity and compatibility.
- **Bug Fixes**
  - Images in search results are now provided as raw Base64-encoded data without data URL prefixes, reducing token usage and ensuring proper display.
- **Documentation**
  - Added a decision record outlining the adoption of the MCP ImageContent format for image handling.
- **Refactor**
  - Renamed the image inclusion parameter from `includeImagesAsBase64` to `includeImageContent` across the app for consistency.
- **Tests**
  - Updated tests to reflect the new image content format and parameter name changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->